### PR TITLE
Keep exception root cause for good stacktraces

### DIFF
--- a/drools-framework-runtime-entity/pom.xml
+++ b/drools-framework-runtime-entity/pom.xml
@@ -43,4 +43,12 @@
       </plugin>
     </plugins>
   </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/drools-framework-runtime-entity/src/main/java/org/chtijbug/drools/runtime/DroolsChtijbugException.java
+++ b/drools-framework-runtime-entity/src/main/java/org/chtijbug/drools/runtime/DroolsChtijbugException.java
@@ -25,6 +25,7 @@ public class DroolsChtijbugException extends  Exception implements Serializable 
 
     }
     public DroolsChtijbugException(String key, String description, Exception originException) {
+        super(key + description, originException);
         this.key = key;
         Description = description;
         this.originException = originException;

--- a/drools-framework-runtime-entity/src/test/java/org/chtijbug/drools/runtime/DroolsChtijbugExceptionTest.java
+++ b/drools-framework-runtime-entity/src/test/java/org/chtijbug/drools/runtime/DroolsChtijbugExceptionTest.java
@@ -1,0 +1,16 @@
+package org.chtijbug.drools.runtime;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertNotNull;
+
+public class DroolsChtijbugExceptionTest {
+    @Test
+    public void should_keep_root_cause()  {
+        IllegalArgumentException rootCause = new IllegalArgumentException();
+
+        DroolsChtijbugException chtijbugException = new DroolsChtijbugException("key", "bla", rootCause);
+
+        assertNotNull(chtijbugException.getCause());
+    }
+}


### PR DESCRIPTION
The goal is to enable fast error searching using log files
